### PR TITLE
Jp product page

### DIFF
--- a/intuition-shop/api/db.json
+++ b/intuition-shop/api/db.json
@@ -7,5 +7,47 @@
       "password": "password",
       "id": 1
     }
+  ],
+  "products": [
+    {
+      "name": "Plain White Sweatshirt",
+      "description": "Plain white hooded sweatshirt made with a mixture of high quality fabrics.",
+      "price": "$24.99",
+      "quantity": 30,
+      "sizes": ["Small", "Medium", "Large"],
+      "sku": "SKU-W789",
+      "imageUrl": "https://images.pexels.com/photos/6311449/pexels-photo-6311449.jpeg?cs=srgb&dl=pexels-monstera-6311449.jpg&fm=jpg",
+      "id": 1
+    },
+    {
+      "name": "Light Green Sweatpants",
+      "description": "Soft cotton sweatpants in light green.",
+      "price": "$19.99",
+      "quantity": 20,
+      "sizes": ["Small", "Medium", "Large"],
+      "sku": "SKU-W788",
+      "imageUrl": "https://images.pexels.com/photos/9775733/pexels-photo-9775733.jpeg?cs=srgb&dl=pexels-shvets-production-9775733.jpg&fm=jpg",
+      "id": 2
+    },
+    {
+      "name": "Beige Sweatshirt",
+      "description": "Beige sweatshirt weaved with a mixture of high quality fabrics.",
+      "price": "$19.99",
+      "quantity": 20,
+      "sizes": ["Small", "Medium", "Large"],
+      "sku": "SKU-W787",
+      "imageUrl": "https://images.pexels.com/photos/6311670/pexels-photo-6311670.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260",
+      "id": 3
+    },
+    {
+      "name": "Black Sweatshirt",
+      "description": "Black sweatshirt weaved with a mixture of high quality fabrics.",
+      "price": "$24.99",
+      "quantity": 15,
+      "sizes": ["Small", "Medium", "Large"],
+      "sku": "SKU-W786",
+      "imageUrl": "https://images.pexels.com/photos/6311628/pexels-photo-6311628.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260",
+      "id": 4
+    }
   ]
 }

--- a/intuition-shop/src/App.js
+++ b/intuition-shop/src/App.js
@@ -4,11 +4,14 @@ import { Route, Routes } from "react-router-dom";
 import { ApplicationViews } from './ApplicationViews';
 import { BrowserRouter as Router } from "react-router-dom";
 import { Navbar } from './components/nav/Navbar';
+import { ProductProvider } from './providers/ProductProvider';
 
 
 export const App = () => (
   <Router>
-    <ApplicationViews />
+    <ProductProvider>
+      <ApplicationViews />
+    </ProductProvider>
   </ Router>
 );
 

--- a/intuition-shop/src/ApplicationViews.js
+++ b/intuition-shop/src/ApplicationViews.js
@@ -3,13 +3,19 @@ import { Route, Routes } from "react-router-dom";
 import { HomePage } from "./components/HomePage";
 import { Login } from "./components/auth/Login";
 import { Register } from "./components/auth/Register";
+import { ProductList } from "./components/products/ProductList";
+import { ProductProvider } from "./providers/ProductProvider";
 
 export const ApplicationViews = () => {
     return (
         <main>
             <Routes>
                 <Route exact path="/" element={<HomePage />} /> 
+
+            
+                    <Route exact path="/products" element={<ProductList />} />
                 
+
                 <Route exact path="/login" element={<Login />} />
 
                 <Route exact path="/register" element={<Register />} />

--- a/intuition-shop/src/components/products/Product.css
+++ b/intuition-shop/src/components/products/Product.css
@@ -1,7 +1,3 @@
-.produt-image {
-    align-self: center;
-}
-
 .card-image {
     display: flex;
     justify-content: center;

--- a/intuition-shop/src/components/products/Product.css
+++ b/intuition-shop/src/components/products/Product.css
@@ -1,0 +1,20 @@
+.produt-image {
+    align-self: center;
+}
+
+.card-image {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 2em;
+    padding-bottom: 3em;
+}
+
+.card-image:hover {
+    opacity: 0.3;
+}
+
+.price-and-icons {
+    display: flex;
+    justify-content: space-between;
+}

--- a/intuition-shop/src/components/products/Product.js
+++ b/intuition-shop/src/components/products/Product.js
@@ -1,0 +1,37 @@
+import React, { useState, useContext, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { ProductContext } from "../../providers/ProductProvider";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCartPlus, faHeart } from "@fortawesome/free-solid-svg-icons";
+import "./Product.css"
+
+
+export const Product = ({ product }) => {
+    
+    const { getProductById } = useContext(ProductContext);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        getProductById()
+    }, []);
+
+    return (
+        <>
+            <div class="column is-one-quarter product-card is-flex">
+                <div class="card product-card">
+                    <div class="card-image">
+                        <figure class="image product-image-container is-128x128">
+                            <img className="product-image is-clickable" src={product.image} />
+                        </figure>
+                    </div>
+                    <div class="card-content mt-4">
+                        <div class="media-content">
+                            <p class="title is-5 has-text-grey has-text-weight-light">{product.title}</p>
+                            <p class="subtitle pt-2 is-4 product-price">$ {product.price}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/intuition-shop/src/components/products/ProductList.css
+++ b/intuition-shop/src/components/products/ProductList.css
@@ -1,0 +1,5 @@
+.products-list {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 2rem 1rem 2rem 1rem;
+}

--- a/intuition-shop/src/components/products/ProductList.js
+++ b/intuition-shop/src/components/products/ProductList.js
@@ -1,0 +1,34 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ProductContext } from "../../providers/ProductProvider";
+import { Navbar } from "../nav/Navbar";
+import { Product } from "./Product";
+import "./ProductList.css"
+
+
+export const ProductList = () => {
+
+    const { products, getProducts} = useContext(ProductContext);
+
+    const [ filteredProducts, setFilteredProducts ] = useState([]);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        getProducts();
+    }, []);
+
+    return (
+        <>
+            <Navbar />
+            <div class="columns is-mobile products-list ">
+                    {
+                        products.map(product => {
+                            return (
+                                    <Product key={product.id} product={product} />
+                            )
+                        })
+                    }
+            </div>
+        </>
+    )
+}

--- a/intuition-shop/src/providers/ProductProvider.js
+++ b/intuition-shop/src/providers/ProductProvider.js
@@ -1,0 +1,107 @@
+import React, { useState, createContext } from "react";
+
+// The context is imported and used by individual components that need data. A context stores a certain kind of data to be used in your application. Therefore, when you create a dta provider component in React you need to create a context. Nothing is stored in the context when it's defined. At this point, it's just an empty warehouse waiting to be filled.
+export const ProductContext = createContext();
+
+// This component establishes what data can be used
+export const ProductProvider = (props) => {
+    const [products, setProducts] = useState([]);
+    const [ searchTerms, setSearchTerms ] = useState("");
+
+    const getProducts = () => {
+        return fetch("https://fakestoreapi.com/products/category/electronics")
+        .then(res => res.json())
+        .then(setProducts)
+    }
+
+    const addProduct = productObj => {
+        return fetch("https://fakestoreapi.com/products", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(productObj)
+        })
+        .then(response => response.json())
+        .then(getProductsById)
+    }
+
+    const userId = localStorage.getItem("nuhabit_user")
+
+    const getProductsById = () => {
+        return fetch(`http://localhost:8088/products?userId=${userId}`)
+            .then(res => res.json())
+            .then(setProducts)
+    }
+
+    const getProductById = (id) => {
+        return fetch(`https://fakestoreapi.com/products/${id}`)
+            .then(res => res.json())
+    }
+
+    const releaseProduct = productId => {
+        return fetch(`http://localhost:8088/products/${productId}`, {
+            method: "DELETE"
+        })
+            .then(getProductsById)
+    }
+
+    const completeProduct = productId => {
+        return fetch(`http://localhost:8088/products/${productId}`, {
+            method: "PATCH",
+            headers: {
+                'Content-type': 'application/json'
+            },
+            body: JSON.stringify({
+                completed: true
+            })        
+        })
+        .then(getProducts)
+    }
+
+    const uncompleteProduct = productId => {
+        return fetch(`http://localhost:8088/products/${productId}`, {
+            method: "PATCH",
+            headers: {
+                'Content-type': 'application/json'
+            },
+            body: JSON.stringify({
+                completed: false
+            })        
+        })
+        .then(getProducts)
+    }
+
+    const completedProductDate = productId => {
+        return fetch(`http://localhost:8088/products/${productId}`, {
+            method: "PATCH",
+            headers: {
+                'Content-type': 'application/json'
+            },
+            body: JSON.stringify({
+                completedDate: new Date()
+            })        
+        })
+        .then(getProducts)
+    }
+
+    const updateProduct = product => {
+        return fetch(`http://localhost:8088/products/${product.id}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify(product)
+        })
+          .then(getProducts)
+      }
+
+        // You return a context provider which has the 'animals' state, 'getAnimals' function, anmd the 'addAnimal' function as keys. This allows any child elements to access them.
+        return (
+            <ProductContext.Provider value={{
+                products, getProducts, addProduct, getProductsById, getProductById, releaseProduct, completeProduct, uncompleteProduct, completedProductDate, updateProduct, searchTerms, setSearchTerms
+            }}>
+                {props.children}
+            </ProductContext.Provider>
+        )
+}

--- a/intuition-shop/src/providers/ProductProvider.js
+++ b/intuition-shop/src/providers/ProductProvider.js
@@ -26,10 +26,10 @@ export const ProductProvider = (props) => {
         .then(getProductsById)
     }
 
-    const userId = localStorage.getItem("nuhabit_user")
+    const userId = localStorage.getItem("intutition_shop_user")
 
     const getProductsById = () => {
-        return fetch(`http://localhost:8088/products?userId=${userId}`)
+        return fetch(`https://fakestoreapi.com/products/?userId=${userId}`)
             .then(res => res.json())
             .then(setProducts)
     }
@@ -40,14 +40,14 @@ export const ProductProvider = (props) => {
     }
 
     const releaseProduct = productId => {
-        return fetch(`http://localhost:8088/products/${productId}`, {
+        return fetch(`https://fakestoreapi.com/products/${productId}`, {
             method: "DELETE"
         })
             .then(getProductsById)
     }
 
     const completeProduct = productId => {
-        return fetch(`http://localhost:8088/products/${productId}`, {
+        return fetch(`https://fakestoreapi.com/products/${productId}`, {
             method: "PATCH",
             headers: {
                 'Content-type': 'application/json'
@@ -60,7 +60,7 @@ export const ProductProvider = (props) => {
     }
 
     const uncompleteProduct = productId => {
-        return fetch(`http://localhost:8088/products/${productId}`, {
+        return fetch(`https://fakestoreapi.com/products/${productId}`, {
             method: "PATCH",
             headers: {
                 'Content-type': 'application/json'
@@ -73,7 +73,7 @@ export const ProductProvider = (props) => {
     }
 
     const completedProductDate = productId => {
-        return fetch(`http://localhost:8088/products/${productId}`, {
+        return fetch(`https://fakestoreapi.com/products/${productId}`, {
             method: "PATCH",
             headers: {
                 'Content-type': 'application/json'
@@ -86,7 +86,7 @@ export const ProductProvider = (props) => {
     }
 
     const updateProduct = product => {
-        return fetch(`http://localhost:8088/products/${product.id}`, {
+        return fetch(`https://fakestoreapi.com/products/${product.id}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json"


### PR DESCRIPTION
# Description

Created product list page. Right now the API call for the product page is pulling in products from ONLY the electronics category. Each product card shows an image of the product, the title, and price. Hovering over an image lowers the opacity of the image. In the future we need to add a button or clickable text to the image when it is hovered over that takes user to product detail page. Design and functionality is not complete on this page. Need to add filter option and make product cards look better. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How To Test

Go to http://localhost:3000/products and verify the list of products appears. Product, image, title, and price should appear on each product card. Hovering over image should lower opacity.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules